### PR TITLE
fix: support global venv based installation on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ should be applied.
  
     /d/osrelease/Scripts/pip install -e /d/output-publisher
 
-* Ensure /d/osrelease/Scripts on path
+* Put git hub token in /d/osrelease/token
+
+* Work with TPP to ensure /d/osrelease/Scripts on system PATH, and envvar PRIVATE_TOKEN_PATH=/d/osrelease/token is in the system environment.
 
 
 ## Updating

--- a/README.md
+++ b/README.md
@@ -35,13 +35,6 @@ should be applied.
 
 ## Usage summary
 
-### Install
-* Log into L4 server
-* Run `/d/bin/install-osrelease.bat` (or `/e/bin/install-osrelease.bat` on the L3 server)
-* Close the console and reopen it
-* Check you can run `osrelease --help` (you'll get some help text)
-
-### Use
 * Log into L4 server
 * Open a console at the root of the workspace you want to publish (e.g. `/d/Level4Files/workspaces/my-amazing-research`)
   * If doing this on the L3 server (_you shouldn't be..._) then be sure to do this in the `/e/FILESFORL4/workspaces` folder to mitigate the risk of publishing high-privacy outputs
@@ -54,3 +47,26 @@ should be applied.
 * Run `osrelease <github_remote_https_url>` (e.g. `osrelease https://github.com/opensafely/my-amazing-research`)
 * Follow the instructions. It will only publish files you have committed locally, and won't send any intermediate history; just their state as they currently are in the local repo
 
+
+## Installing on TPP level 4 server
+
+* Create or update a checkout 
+
+    git clone https://github.com/opensafely/output-publisher /d/output-publisher
+
+* Create venv at `/d/osrelease`
+
+    /c/Program\ Files\Python39.exe -m pyenv /d/osrelease
+
+* Install into venv
+ 
+    /d/osrelease/Scripts/pip install -e /d/output-publisher
+
+* Ensure /d/osrelease/Scripts on path
+
+
+## Updating
+
+* Update checkout
+
+    cd /d/output-publisher && git pull

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import subprocess
 
-from publisher.release import main
+from publisher.release import main, get_private_token
 
 # Fixtures for these tests:
 #
@@ -14,7 +14,7 @@ from publisher.release import main
 
 def test_successful_push_message(capsys, release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name)
+    main(study_repo_url=study_repo.name, token='')
     captured = capsys.readouterr()
 
     assert captured.out.startswith("Pushed new changes")
@@ -22,7 +22,7 @@ def test_successful_push_message(capsys, release_repo, study_repo):
 
 def test_release_repo_master_branch_unchanged(release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name)
+    main(study_repo_url=study_repo.name, token='')
     os.chdir(study_repo.name)
     committed = pathlib.Path("released_outputs/a/b/committed.txt")
     staged = pathlib.Path("released_outputs/a/b/staged.txt")
@@ -34,7 +34,7 @@ def test_release_repo_master_branch_unchanged(release_repo, study_repo):
 
 def test_release_repo_release_branch_changed(release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name)
+    main(study_repo_url=study_repo.name, token='')
     os.chdir(study_repo.name)
     subprocess.check_output(["git", "checkout", "release-candidates"])
 
@@ -49,7 +49,7 @@ def test_release_repo_release_branch_changed(release_repo, study_repo):
 
 def test_release_repo_commit_history(release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name)
+    main(study_repo_url=study_repo.name, token='')
     os.chdir(study_repo.name)
     log = subprocess.check_output(["git", "log", "--all"], encoding="utf8")
     assert "second commit" in log
@@ -63,7 +63,23 @@ def test_release_repo_commit_history(release_repo, study_repo):
 
 def test_noop_message(capsys, release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name)
-    main(study_repo_url=study_repo.name)
+    main(study_repo_url=study_repo.name, token='')
+    main(study_repo_url=study_repo.name, token='')
     captured = capsys.readouterr()
     assert captured.out.splitlines()[-1] == "Nothing to do!"
+
+
+def test_get_private_token(tmpdir):
+    token_path = tmpdir / 'token'
+    token_path.write_text('file token', 'utf8')
+    assert get_private_token({}) is None
+    assert get_private_token({'PRIVATE_REPO_ACCESS_TOKEN': 'env token'}) == 'env token'
+    assert get_private_token({'PRIVATE_TOKEN_PATH': str(token_path)}) == 'file token'
+    assert get_private_token({'PRIVATE_TOKEN_PATH': '/notexist'}) is None
+    assert get_private_token({
+	'PRIVATE_REPO_ACCESS_TOKEN': 'env token',
+	'PRIVATE_TOKEN_PATH': str(token_path),
+    }) == 'env token'
+    
+    
+


### PR DESCRIPTION
This is a proposal for a globally maintained updateable install of osrelease on the level 4 server. It works by maintaining a checkout of output-publisher in /d/output-publisher, and a virutalenv at /d/osrelease, which that checkout is installed into with -e. This allows us to use git pull to update, and hotfix locally if needed.

Additionally, we place the GH token in /d/osrelease/token, and set an envvar to point to it. This allows us to rotate the token w/o involving TPP. We possibly could do this differently, but KISS.

For this to work we need to:

 - get TPP to add /d/osrelease/Scripts to the *end* of the default system path
 - get TPP to add PRIVATE_TOKEN_PATH=/d/osrelease/token to the default environment.
 - get TPP to allow developers write access to /d/output-publisher and /d/osrelease so anyone can update.
 - write a script in /d/bin/ to clean up user's PATHs if they've already installed their own version (or else their install may take priority)
